### PR TITLE
Increase the number of characters allowed for the TLD 

### DIFF
--- a/build/EFA/lib-EFA-Configure/func_sethostname
+++ b/build/EFA/lib-EFA-Configure/func_sethostname
@@ -24,7 +24,7 @@ function func_sethostname() {
   dncheck=1
   while [ $dncheck != 0 ]
    do
-     if [[ $DOMAINNAME =~ ^[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-z]{2,6}$ ]]
+     if [[ $DOMAINNAME =~ ^[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-z]{2,15}$ ]]
       then
         dncheck=0
       else


### PR DESCRIPTION
New TLDs are much longer than 6 chars.
I was not able to set my domain without changing this regex.