### PR TITLE
allow transport to subdomains as per transport(5)

### DIFF
--- a/build/EFA/lib-EFA-Configure/func_mailsettings
+++ b/build/EFA/lib-EFA-Configure/func_mailsettings
@@ -89,7 +89,7 @@ func_transport-settings(){
                         DOMAINCHECK=1
                         while [ $DOMAINCHECK != 0 ]
                           do
-                            if [[ $DOMAIN =~ ^[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9-]+)*\.[a-z]{2,63}$ ]]; then
+                            if [[ $DOMAIN =~ ^\.?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9-]+)*\.[a-z]{2,63}$ ]]; then
                               DUPLICATECHECK=0
                               for (( y=0; y<$tLen; y+=2 ));
                               do
@@ -167,7 +167,7 @@ func_transport-settings(){
                     DOMAINCHECK=1
                     while [ $DOMAINCHECK != 0 ]
                       do
-                        if [[ $DOMAIN =~ ^[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9-]+)*\.[a-z]{2,63}$ ]]; then
+                        if [[ $DOMAIN =~ ^\.?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9-]+)*\.[a-z]{2,63}$ ]]; then
                           DUPLICATECHECK=0
                           for (( y=0; y<$tLen; y+=2 ));
                             do


### PR DESCRIPTION
Hi,

according to transport(5) you can have subdomains for transport:

.domain transport:nexthop
              Deliver mail for any subdomain of domain through transport to  nex-
              thop.  This  applies  only  when  the  string transport_maps is not
              listed in the parent_domain_matches_subdomains  configuration  set-
              ting.   Otherwise, a domain name matches itself and its subdomains.

