### PR TITLE
Make backup filename more global/sort-friendly

### DIFF
--- a/build/EFA/EFA-Backup
+++ b/build/EFA/EFA-Backup
@@ -53,7 +53,7 @@ function start_purge()
 function start_backup()
 {
   # Get current date and time
-  CDATE=`date +%m%d%Y`
+  CDATE=`date +%Y%m%d`
   CTIME=`date +%H%M%S`
 
   echo "Beginning System Backup at $CDATE $CTIME"


### PR DESCRIPTION
Current backup filenames are of the form "backup-mmddYYYY-HHMMSS.tar.gz", which doesn't sort well/naturally for most of the planet.

This proposal uses the more global/sort-friendly "backup-YYYYmmdd-HHMMSS.tar.gz" form.